### PR TITLE
Assignmentexpression support

### DIFF
--- a/src/morphues.js
+++ b/src/morphues.js
@@ -89,6 +89,14 @@ _.extend(Morpheus.prototype, {
       this.currentScope = oldScope;
 
       this.currentScope.addFunction(nodeMetadata);
+    } ,
+
+    /*
+     * Handles AssignmnetExpression 
+    */
+    AssignmentExpression: function AssignmentExpression(node){
+     var nodeMetadata = this.getNodeMetadata(node.right, node.left);
+     this.currentScope.addOrUpdateVariable(nodeMetadata);
     }
   }
 

--- a/src/morphues.js
+++ b/src/morphues.js
@@ -95,7 +95,12 @@ _.extend(Morpheus.prototype, {
      * Handles AssignmnetExpression 
     */
     AssignmentExpression: function AssignmentExpression(node){
-     var nodeMetadata = this.getNodeMetadata(node.right, node.left);
+      var nodeIdentifier = node.left;
+      if(nodeIdentifier.type === "MemberExpression"){
+          nodeIdentifier = node.left.object;
+          nodeIdentifier.name = nodeIdentifier.name + "." + node.left.property.name;
+      }
+     var nodeMetadata = this.getNodeMetadata(node.right, nodeIdentifier);
      this.currentScope.addOrUpdateVariable(nodeMetadata);
     }
   }

--- a/src/morphues.js
+++ b/src/morphues.js
@@ -70,7 +70,7 @@ _.extend(Morpheus.prototype, {
      */
     VariableDeclarator: function variableDeclarator(node) {
       var nodeMetadata = this.getNodeMetadata(node.init, node.id);
-      this.currentScope.addVariable(nodeMetadata);
+      this.currentScope.addOrUpdateVariable(nodeMetadata);
     },
     /*
      * Handles functions declarations

--- a/src/structures/metadata_provider.js
+++ b/src/structures/metadata_provider.js
@@ -42,6 +42,6 @@ module.exports.getMetadataProvider = function() {
   metadataProvider.registerMetadata("FunctionExpression", require("./metadata/function_metadata"));
   metadataProvider.registerMetadata("FunctionDeclaration", require("./metadata/function_metadata"));
   metadataProvider.registerMetadata("NewExpression", require("./metadata/instance_metadata"));
-
+ 
   return metadataProvider;
 };

--- a/src/structures/scope.js
+++ b/src/structures/scope.js
@@ -15,20 +15,49 @@ var Scope = module.exports = function Scope() {
   this._functionIndex = {};
 };
 
-_.extend(Scope.prototype, {
+function mergeObjectProperties(newItem,oldItems){
+  var result = oldItems;
+  var indexOfProperty = oldItems.length;
+  //look if the property is on old items. if yes update the indexOfProperty
+  for (var i = oldItems.length - 1; i >= 0; i--) {
+   
+   if (oldItems[i].name === newItem.name) {
+        //there is 
+        indexOfProperty = i;
+        break;
+    }
+
+  }
+  result[indexOfProperty] = newItem;
+  return result;
+  }
+
+  _.extend(Scope.prototype, {
 
   /*
    * Add variable to the current scope
    * @param {Metadata} metadata about the variable
    */
-  addOrUpdateVariable: function(metadata) {
-    var index = this._variableIndex[metadata.name]
+   addOrUpdateVariable: function(metadata) {
+    var index = this._variableIndex[metadata.name];
+    if (metadata.name.indexOf(".") != -1) {
+      var varName = metadata.name.substring(0,metadata.name.indexOf("."));
+      var propertyName = metadata.name.substring(metadata.name.indexOf(".")+1,metadata.name.length);
+      var property = {name: propertyName , type: metadata.type};
+      index = this._variableIndex[varName];
+      //todo: what to do if there is no such index
+       oldMetaData =  this.variables[index];
+        var mergedProperties = mergeObjectProperties(property,
+          oldMetaData.properties);
+        this.variables[index].properties = mergedProperties;
+      return;
+    }
     if( index != undefined){
       this.variables[index] = metadata;
     } 
     else {
-    var returnIndex = this.variables.push(metadata);
-    this._variableIndex[metadata.name] = returnIndex - 1;
+      var returnIndex = this.variables.push(metadata);
+      this._variableIndex[metadata.name] = returnIndex - 1;
     }
   },
 
@@ -36,7 +65,7 @@ _.extend(Scope.prototype, {
    * Add function to the current scope
    * @param {FunctionMetadata} function metadata
    */
-  addFunction: function(metadata) {
+   addFunction: function(metadata) {
     var returnIndex = this.functions.push(metadata);
     this._functionIndex[metadata.name] = returnIndex - 1;
   },
@@ -47,7 +76,7 @@ _.extend(Scope.prototype, {
    * @param  {String} variable name
    * @return {Metadata} variable metadata
    */
-  getVariableMetadata: function(name) {
+   getVariableMetadata: function(name) {
     if(_.has(this._variableIndex, name)) {
       var variableIndex = this._variableIndex[name];
       return this.variables[variableIndex];
@@ -61,7 +90,7 @@ _.extend(Scope.prototype, {
    * @param  {String} function name
    * @return {FunctionMetadata} function metadata
    */
-  getFunctionMetadata: function(name) {
+   getFunctionMetadata: function(name) {
     if(_.has(this._functionIndex, name)) {
       var functionIndex = this._functionIndex[name];
       return this.functions[functionIndex];

--- a/src/structures/scope.js
+++ b/src/structures/scope.js
@@ -21,9 +21,15 @@ _.extend(Scope.prototype, {
    * Add variable to the current scope
    * @param {Metadata} metadata about the variable
    */
-  addVariable: function(metadata) {
+  addOrUpdateVariable: function(metadata) {
+    var index = this._variableIndex[metadata.name]
+    if( index != undefined){
+      this.variables[index] = metadata;
+    } 
+    else {
     var returnIndex = this.variables.push(metadata);
     this._variableIndex[metadata.name] = returnIndex - 1;
+    }
   },
 
   /*

--- a/test/expression_statement_tests.js
+++ b/test/expression_statement_tests.js
@@ -1,0 +1,21 @@
+var assert = require("assert"),
+helper = require("./helper"),
+morphues = require("../src/morphues");
+
+describe("Expression Statements", function() {
+	
+	describe("Assignment Expression",function() {
+		it("should be able to detect variable assignnment to number when he was string before",function(){
+			var results = morphues.analyze(helper.loadFixture("expressions_statements/declare_string_and_do_number_assignment"));
+
+			var expectedResult = {
+				variables: [
+				{ name: "eliran", type: "number" }
+				]
+			};
+
+			assert.deepEqual(results.variables, expectedResult.variables);
+		});
+	});
+
+});

--- a/test/expression_statement_tests.js
+++ b/test/expression_statement_tests.js
@@ -16,6 +16,56 @@ describe("Expression Statements", function() {
 
 			assert.deepEqual(results.variables, expectedResult.variables);
 		});
+
+		it("should be able to add property to existing object",function(){
+			var results = morphues.analyze(helper.loadFixture("expressions_statements/add_property_to_object"));
+
+			var expectedResult = {
+				variables: [
+				{ 
+					name: "obj",
+					type: "object",
+					properties: [
+					{
+						name: "n",
+						type: "number"
+					},
+					{
+						name: "b",
+						type: "string"
+					}
+					]
+				}
+				]
+			};
+
+			assert.deepEqual(results.variables, expectedResult.variables);
+		});
+
+		it("should be able to update type of property for existing object",function(){
+			var results = morphues.analyze(helper.loadFixture("expressions_statements/change_property_type_of_an_object"));
+
+			var expectedResult = {
+				variables: [
+				{ 
+					name: "obj",
+					type: "object",
+					properties: [
+					{
+						name: "n",
+						type: "number"
+					},
+					{
+						name: "b",
+						type: "number"
+					}
+					]
+				}
+				]
+			};
+
+			assert.deepEqual(results.variables, expectedResult.variables);
+		});
 	});
 
 });

--- a/test/fixtures/expressions_statements/add_property_to_object.js
+++ b/test/fixtures/expressions_statements/add_property_to_object.js
@@ -1,0 +1,2 @@
+var obj = {n: 1};
+obj.b = "bye";

--- a/test/fixtures/expressions_statements/change_property_type_of_an_object.js
+++ b/test/fixtures/expressions_statements/change_property_type_of_an_object.js
@@ -1,0 +1,2 @@
+var obj = {n: 1 , b:"bye"};
+obj.b = 2;

--- a/test/fixtures/expressions_statements/declare_string_and_do_number_assignment.js
+++ b/test/fixtures/expressions_statements/declare_string_and_do_number_assignment.js
@@ -1,0 +1,2 @@
+var eliran = "42";
+eliran = 42;

--- a/test/fixtures/variable_declarations/multiple_declaration.js
+++ b/test/fixtures/variable_declarations/multiple_declaration.js
@@ -1,0 +1,2 @@
+var eliran = "42";
+var eliran = 42;

--- a/test/sanity_test.js
+++ b/test/sanity_test.js
@@ -32,6 +32,18 @@ describe("Variable Declarations", function() {
 
   });
 
+ it("should be able to detect multiple declaration of the same Variable", function() {
+    var results = morphues.analyze(helper.loadFixture("variable_declarations/multiple_declaration"));
+
+    var expectedResult = {
+      variables: [
+        { name: "eliran", type: "number" }
+      ]
+    };
+
+    assert.deepEqual(results.variables, expectedResult.variables);
+  });
+
 
   describe("Array Delcaration", function(){
 


### PR DESCRIPTION
support on AssignmentExpression
1. add option to multiple declare variable
2. update type of an object if needed when assignment takes place 
   example: var a = "a" ; 
                  a  =3 ;
than type of a will be number
3. support on adding property to an object  or changing its type
   example var a = {id:1};
                a.name = "eliran"; // a now have two properties
                a.id = "id1"; //a.id type is now number
4. also added tests folder for expressions
